### PR TITLE
fixes #1: conditionally separates variable declarations

### DIFF
--- a/slowmo/scope-mangler.js
+++ b/slowmo/scope-mangler.js
@@ -42,8 +42,11 @@ define(function(require, module, exports) {
       node.declarations.forEach(function(decl) {
         decls.push(makeDeclareCode(decl.id.name, decl.init, decl));
       });
-      var newCode = decls.join(' || ');
-      if (node.parent.type != "ForStatement")
+
+      var parentIsFor = node.parent.type === "ForStatement";
+      var separator = parentIsFor ? " || " : " ; ";
+      var newCode = decls.join(separator);
+      if (!parentIsFor)
         newCode += ';'
       return node.update(newCode);
     }

--- a/test/test-scope-mangler.js
+++ b/test/test-scope-mangler.js
@@ -87,6 +87,10 @@ defineTests([
     declTest("var i, j = 2;", [["i", undefined, "i"], ["j", 2, "j = 2"]]);
   });
 
+  test("var decls w/ commas work with value first", function() {
+    declTest("var i = 3, j = 2;", [["i", 3, "i = 3"], ["j", 2, "j = 2"]]);
+  });
+
   test("multiple var decls work", function() {
     declTest("var i; var j = 2;",
              [["i", undefined, "i"], ["j", 2, "j = 2"]]);


### PR DESCRIPTION
fixes #1: conditionally separates variable declarations
using or caused lazy evaluation of truthy assignments. if not in a for loop, we can use ; to separate instead

added test for example failing case
