### PR TITLE
adds undefined to exposed list

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,8 @@ var EXPOSED_GLOBALS = [
   "encodeURI",
   "decodeURI",
   "JSON",
-  "Math"
+  "Math",
+  "undefined"
 ];
 
 function output(type, msg) {


### PR DESCRIPTION
previously including undefined in the box would complain that it was not defined. this fixes that in the example
